### PR TITLE
<fix>(popup): when center is true, the max-width of cube-popup-content should be 100%, not 150%

### DIFF
--- a/src/components/popup/popup.vue
+++ b/src/components/popup/popup.vue
@@ -78,20 +78,19 @@
       background-color: rgba(0, 0, 0, .1)
       margin-left: -10px
   .cube-popup-container
-    transform: translate(100%, 100%)
     .cube-popup-content
       position: absolute
-      top: 0
       left: 0
+      bottom: 0
       width: 100%
       box-sizing: border-box
-      transform: translate(-100%, -100%)
     &.cube-popup-center
       transform: translate(50%, 50%)
       .cube-popup-content
         position: absolute
         top: 0
         left: 0
+        bottom: auto
         width: auto
         transform: translate(-50%, -50%)
 </style>

--- a/src/components/popup/popup.vue
+++ b/src/components/popup/popup.vue
@@ -79,18 +79,19 @@
       margin-left: -10px
   .cube-popup-container
     transform: translate(100%, 100%)
-  .cube-popup-content
-    position: absolute
-    top: 0
-    left: 0
-    width: 100%
-    box-sizing: border-box
-    transform: translate(-100%, -100%)
-  .cube-popup-center
     .cube-popup-content
       position: absolute
-      top: -50%
-      left: -50%
-      width: auto
-      transform: translate(-50%, -50%)
+      top: 0
+      left: 0
+      width: 100%
+      box-sizing: border-box
+      transform: translate(-100%, -100%)
+    &.cube-popup-center
+      transform: translate(50%, 50%)
+      .cube-popup-content
+        position: absolute
+        top: 0
+        left: 0
+        width: auto
+        transform: translate(-50%, -50%)
 </style>


### PR DESCRIPTION
…t should be 100%, not 150%

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow DiDi's [contributing guide](https://github.com/didi/cube-ui/blob/master/CONTRIBUTING.md).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
