### PR TITLE
<fix>(popup): when use center layout, the max-width of content should…

### DIFF
--- a/src/components/popup/popup.vue
+++ b/src/components/popup/popup.vue
@@ -92,5 +92,6 @@
       top: -50%
       left: -50%
       width: auto
+      max-width: 100%
       transform: translate(-50%, -50%)
 </style>


### PR DESCRIPTION
… be 100%, not 150%

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow DiDi's [contributing guide](https://github.com/didi/cube-ui/blob/master/CONTRIBUTING.md).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
