### PR TITLE
修复 picker 通过 setData 改变数据，列数变化时产生的问题

### DIFF
--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -125,11 +125,13 @@
         let pickerSelectedText = []
 
         const dataLength = this.pickerData.length
+        const selectedValLength = this.pickerSelectedVal.length
 
-        const extraVal = this.pickerSelectedVal.splice(dataLength)
-        const extraIndex = this.pickerSelectedIndex.splice(dataLength)
-
-        if (extraVal.length || extraIndex.length) {
+        if (selectedValLength !== dataLength) {
+          if (selectedValLength > dataLength) {
+            this.pickerSelectedVal.splice(dataLength)
+            this.pickerSelectedIndex.splice(dataLength)
+          }
           changed = true
         }
 

--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -123,9 +123,16 @@
 
         let changed = false
         let pickerSelectedText = []
-        this.pickerSelectedVal = []
 
-        for (let i = 0; i < this.pickerData.length; i++) {
+        const dataLength = this.pickerData.length
+        const selectedValLength = this.pickerSelectedVal.length
+
+        if (dataLength !== selectedValLength) {
+          changed = true
+          this.pickerSelectedVal.splice(dataLength, selectedValLength - dataLength)
+        }
+
+        for (let i = 0; i < dataLength; i++) {
           let index = this.wheels[i].getSelectedIndex()
           this.pickerSelectedIndex[i] = index
 

--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -124,19 +124,16 @@
         let changed = false
         let pickerSelectedText = []
 
-        const newDataLength = this.pickerData.length
-        const oldDataLength = this.pickerSelectedVal.length
+        const dataLength = this.pickerData.length
 
-        if (newDataLength !== oldDataLength) {
-          if (newDataLength < oldDataLength) {
-            const spliceArgs = [newDataLength, oldDataLength - newDataLength]
-            this.pickerSelectedVal.splice(...spliceArgs)
-            this.pickerSelectedIndex.splice(...spliceArgs)
-          }
+        const extraVal = this.pickerSelectedVal.splice(dataLength)
+        const extraIndex = this.pickerSelectedIndex.splice(dataLength)
+
+        if (extraVal.length || extraIndex.length) {
           changed = true
         }
 
-        for (let i = 0; i < newDataLength; i++) {
+        for (let i = 0; i < dataLength; i++) {
           let index = this.wheels[i].getSelectedIndex()
           this.pickerSelectedIndex[i] = index
 
@@ -205,7 +202,7 @@
               this._createWheel(wheelWrapper, i)
               this.wheels[i].wheelTo(this.pickerSelectedIndex[i])
             })
-            const extraWheels = this.wheels.splice(this.pickerData.length, this.wheels.length - this.pickerData.length)
+            const extraWheels = this.wheels.splice(this.pickerData.length)
             extraWheels.forEach((wheel) => {
               wheel.destroy()
             })

--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -123,6 +123,8 @@
 
         let changed = false
         let pickerSelectedText = []
+        this.pickerSelectedVal = []
+
         for (let i = 0; i < this.pickerData.length; i++) {
           let index = this.wheels[i].getSelectedIndex()
           this.pickerSelectedIndex[i] = index
@@ -187,10 +189,12 @@
         this.pickerData = data.slice()
         if (this.isVisible) {
           this.$nextTick(() => {
-            this.wheels.forEach((wheel, i) => {
-              wheel.refresh()
-              wheel.wheelTo(this.pickerSelectedIndex[i])
+            const wheelWrapper = this.$refs.wheelWrapper
+            this.pickerData.forEach((item, i) => {
+              this._createWheel(wheelWrapper, i)
+              this.wheels[i].wheelTo(this.pickerSelectedIndex[i])
             })
+            this.wheels.splice(this.pickerData.length, this.wheels.length - this.pickerData.length)
           })
         } else {
           this.dirty = true

--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -124,15 +124,19 @@
         let changed = false
         let pickerSelectedText = []
 
-        const dataLength = this.pickerData.length
-        const selectedValLength = this.pickerSelectedVal.length
+        const newDataLength = this.pickerData.length
+        const oldDataLength = this.pickerSelectedVal.length
 
-        if (dataLength !== selectedValLength) {
+        if (newDataLength !== oldDataLength) {
+          if (newDataLength < oldDataLength) {
+            const spliceArgs = [newDataLength, oldDataLength - newDataLength]
+            this.pickerSelectedVal.splice(...spliceArgs)
+            this.pickerSelectedIndex.splice(...spliceArgs)
+          }
           changed = true
-          this.pickerSelectedVal.splice(dataLength, selectedValLength - dataLength)
         }
 
-        for (let i = 0; i < dataLength; i++) {
+        for (let i = 0; i < newDataLength; i++) {
           let index = this.wheels[i].getSelectedIndex()
           this.pickerSelectedIndex[i] = index
 
@@ -201,7 +205,10 @@
               this._createWheel(wheelWrapper, i)
               this.wheels[i].wheelTo(this.pickerSelectedIndex[i])
             })
-            this.wheels.splice(this.pickerData.length, this.wheels.length - this.pickerData.length)
+            const extraWheels = this.wheels.splice(this.pickerData.length, this.wheels.length - this.pickerData.length)
+            extraWheels.forEach((wheel) => {
+              wheel.destroy()
+            })
           })
         } else {
           this.dirty = true

--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -168,11 +168,12 @@
         this.isVisible = true
         if (!this.wheels || this.dirty) {
           this.$nextTick(() => {
-            this.wheels = []
+            this.wheels = this.wheels || []
             let wheelWrapper = this.$refs.wheelWrapper
             for (let i = 0; i < this.pickerData.length; i++) {
               this._createWheel(wheelWrapper, i)
             }
+            this.dirty && this._destroyExtraWheels()
             this.dirty = false
           })
         } else {
@@ -202,10 +203,7 @@
               this._createWheel(wheelWrapper, i)
               this.wheels[i].wheelTo(this.pickerSelectedIndex[i])
             })
-            const extraWheels = this.wheels.splice(this.pickerData.length)
-            extraWheels.forEach((wheel) => {
-              wheel.destroy()
-            })
+            this._destroyExtraWheels()
           })
         } else {
           this.dirty = true
@@ -276,6 +274,15 @@
           this.wheels[i].refresh()
         }
         return this.wheels[i]
+      },
+      _destroyExtraWheels() {
+        const dataLength = this.pickerData.length
+        if (this.wheels.length > dataLength) {
+          const extraWheels = this.wheels.splice(dataLength)
+          extraWheels.forEach((wheel) => {
+            wheel.destroy()
+          })
+        }
       },
       _canConfirm() {
         return this.wheels.every((wheel) => {

--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -171,7 +171,7 @@
             this.wheels = this.wheels || []
             let wheelWrapper = this.$refs.wheelWrapper
             for (let i = 0; i < this.pickerData.length; i++) {
-              this._createWheel(wheelWrapper, i)
+              this._createWheel(wheelWrapper, i).enable()
             }
             this.dirty && this._destroyExtraWheels()
             this.dirty = false


### PR DESCRIPTION
1. 列数增加: 增加的列对应的 scroll 未实例化无法滚动
2. 列数减少: pickerSelectedVal 保留了变化前选中的值

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow DiDi's [contributing guide](https://github.com/didi/cube-ui/blob/master/CONTRIBUTING.md).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
