### PR TITLE
[fix]{drawer-panel.vue} flex item height: 100% bug

### DIFF
--- a/src/components/drawer/drawer-panel.vue
+++ b/src/components/drawer/drawer-panel.vue
@@ -94,10 +94,11 @@
       margin-left: -67px
     &:first-child
       box-shadow: none
-    .cube-drawer-scroll-wrapper // fix flex item height: 100% bug in android
-      position: absolute
-      top: 0
-      bottom: 0
+  .cube-drawer-scroll-wrapper // fix flex item height: 100% bug in android
+    position: absolute
+    top: 0
+    bottom: 0
+    width: 100%
 
   .cube-drawer-move-enter, .cube-drawer-move-leave-to
     transform: translate(67px, 0)

--- a/src/components/drawer/drawer-panel.vue
+++ b/src/components/drawer/drawer-panel.vue
@@ -97,8 +97,9 @@
   .cube-drawer-scroll-wrapper // fix flex item height: 100% bug in android
     position: absolute
     top: 0
-    bottom: 0
+    left: 0
     width: 100%
+    height: 100%
 
   .cube-drawer-move-enter, .cube-drawer-move-leave-to
     transform: translate(67px, 0)

--- a/src/components/drawer/drawer-panel.vue
+++ b/src/components/drawer/drawer-panel.vue
@@ -1,13 +1,15 @@
 <template>
   <transition name="cube-drawer-move">
     <div class="cube-drawer-panel" v-show="isVisible">
-      <cube-scroll ref="scroll" :data="data">
-        <ul class="cube-drawer-list">
-          <slot>
-            <cube-drawer-item v-for="(item, i) in data" :item="item" :key="i" :index="i" />
-          </slot>
-        </ul>
-      </cube-scroll>
+      <div class="cube-drawer-scroll-wrapper">
+        <cube-scroll ref="scroll" :data="data">
+          <ul class="cube-drawer-list">
+            <slot>
+              <cube-drawer-item v-for="(item, i) in data" :item="item" :key="i" :index="i" />
+            </slot>
+          </ul>
+        </cube-scroll>
+      </div>
     </div>
   </transition>
 </template>
@@ -83,7 +85,6 @@
   .cube-drawer-panel
     position: relative
     z-index: 1
-    height: 100%
     flex: 1
     width: 170px
     overflow: hidden
@@ -93,6 +94,10 @@
       margin-left: -67px
     &:first-child
       box-shadow: none
+    .cube-drawer-scroll-wrapper // fix flex item height: 100% bug in android
+      position: absolute
+      top: 0
+      bottom: 0
 
   .cube-drawer-move-enter, .cube-drawer-move-leave-to
     transform: translate(67px, 0)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow DiDi's [contributing guide](https://github.com/didi/cube-ui/blob/master/CONTRIBUTING.md).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

fix issue [#183](https://github.com/didi/cube-ui/issues/183): flex item `height: 100%` not correctly in Android
