### PR TITLE
[NEW FEATURE] Changed rendering mode for text item in picker.

### DIFF
--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -27,7 +27,8 @@
               <div v-for="(data,index) in pickerData" :key="index">
                 <!-- The class name of the ul and li need be configured to BetterScroll. -->
                 <ul class="cube-picker-wheel-scroll">
-                  <li v-for="(item,index) in data" class="cube-picker-wheel-item" :key="index">{{item[textKey]}}</li>
+                  <li v-for="(item,index) in data" class="cube-picker-wheel-item" :key="index" v-html="item[textKey]">
+                  </li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
Hi there,

Thanks for this awesome UI components library, it is very handy and easy to use. 

However, I need to be able to put custom icons/images as elements in the picker (I am building a card game where you may select the type of card, for example spades or hearths). Since there is only text rendering in the picker, I made in this PR the simplest changes to be able to handle dynamic HTML string templates rather than just text, which would solve my issue. See below for the details.

Changed the text rendering mode in the picker component,
From:
- Using innerText rendering with `<li>{{...}}</li>`
To:
- Using innerHTML rendering with `<li v-html="..."></li>`

This does not change anything for text items, but allows to insert HTML templates, especially icons and all the tests seem to be ok.

Thanks for your consideration,

Cheers,

NikolaLohinski