### PR TITLE
fix(slide): should update `currentPageIndex` when `initialIndex` change

### DIFF
--- a/src/components/slide/slide.vue
+++ b/src/components/slide/slide.vue
@@ -130,6 +130,7 @@
       initialIndex(newIndex) {
         if (newIndex !== this.currentPageIndex) {
           this.slide && this.slide.goToPage(newIndex)
+          this.currentPageIndex = newIndex;
         }
       }
     },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow DiDi's [contributing guide](https://github.com/didi/cube-ui/blob/master/CONTRIBUTING.md).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Fix issue #278.

Change `initialIndex` when cube-slide has not create its `slide`, nothing will happen.

That's not right, new index should be remembered and applied when next time init its inner `slide`.