### PR TITLE
fix:picker、scroll、slide component cannot scroll on some kind of pc de…

### DIFF
--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -232,7 +232,9 @@
               wheelItemClass: 'cube-picker-wheel-item'
             },
             swipeTime: this.swipeTime,
-            observeDOM: false
+            observeDOM: false,
+            // fix issue #397
+            disableMouse: false
           })
           wheel.on('scrollEnd', () => {
             this.$emit(EVENT_CHANGE, i, wheel.getSelectedIndex())

--- a/src/components/scroll/scroll.vue
+++ b/src/components/scroll/scroll.vue
@@ -263,7 +263,9 @@
         let options = Object.assign({}, DEFAULT_OPTIONS, {
           scrollY: this.direction === DIRECTION_V,
           scrollX: this.direction === DIRECTION_H,
-          probeType: this.needListenScroll ? 3 : 1
+          probeType: this.needListenScroll ? 3 : 1,
+          // fix issue #397
+          disableMouse: false
         }, this.options)
 
         this.scroll = new BScroll(this.$refs.wrapper, options)

--- a/src/components/slide/slide.vue
+++ b/src/components/slide/slide.vue
@@ -201,7 +201,9 @@
             threshold: this.threshold,
             speed: this.speed
           },
-          stopPropagation: this.stopPropagation
+          stopPropagation: this.stopPropagation,
+          // fix issue #397
+          disableMouse: false
         }, this.options)
 
         this.slide = new BScroll(this.$refs.slide, options)


### PR DESCRIPTION
This pull request is for solving the issue #397.

In the code of picker、scroll、slide component, I set the configure of "disableMouse" to "false", which is the configure of better-scroll. This change is to solving problem that those components cannot be use on some PC devices, which have touch event on the window object.