### PR TITLE
fix(upload): props:auto not work

### DIFF
--- a/src/components/upload/upload.vue
+++ b/src/components/upload/upload.vue
@@ -144,13 +144,18 @@
           const file = this.files[i]
           const status = file.status
           if (status === STATUS_READY || (retry && status === STATUS_ERROR && file._retryId !== this.retryId)) {
-            ajaxUpload(file, options, (file) => {
-              if (status === STATUS_ERROR) {
-                file._retryId = this.retryId
-              }
-              this.$emit(file.status === STATUS_SUCCESS ? EVENT_SUCCESS : EVENT_ERROR, file)
-              this.upload(retry)
-            })
+            ((index) => {
+              ajaxUpload(file, options, (file) => {
+                if (status === STATUS_ERROR) {
+                  file._retryId = this.retryId
+                }
+                this.$emit(file.status === STATUS_SUCCESS ? EVENT_SUCCESS : EVENT_ERROR, file)
+                this.upload(retry)
+                if (index === len - 1 && !this.auto) {
+                  this.paused = true
+                }
+              })
+            })(i)
             uploadingCount++
           } else if (status === STATUS_UPLOADING) {
             uploadingCount++


### PR DESCRIPTION
Hi, all:
Although the props `auto` is set to false,  the component's `start` or `retry` method will reset `paused` to false.  So for the second upload, the component uploads the file automatically. So we should reset `paused` to `true` after uploading If the property `auto` is set to `false` by default.

- device mode: chrome v72.0.3626.109
- API version: 1.12.16

* [x] Make sure you follow DiDi's [contributing guide](https://github.com/didi/cube-ui/blob/master/CONTRIBUTING.md).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
