### PR TITLE
fix time-picker and add it's test

### DIFF
--- a/src/components/time-picker/time-picker.vue
+++ b/src/components/time-picker/time-picker.vue
@@ -258,8 +258,11 @@
       _updateSelectedIndex() {
         const value = this.value
         const minTime = this.minTime
-
-        if (value <= +minTime) {
+        // fix the value last choose was changed when time-picker is opened again
+        const comparativeTime = (this.min || this.min === 0)
+          ? +minTime
+          : Math.floor(minTime / MINUTE_TIMESTAMP) * MINUTE_TIMESTAMP
+        if (value <= comparativeTime) {
           this.selectedIndex = [0, 0, 0]
         } else {
           // calculate dayIndex

--- a/test/unit/specs/time-picker.spec.js
+++ b/test/unit/specs/time-picker.spec.js
@@ -235,6 +235,36 @@ describe('TimePicker', () => {
     console.warn = originWarn
   })
 
+  it('should show the value last choose when time-picker is opened again', function (done) {
+    const selectHandle = sinon.spy()
+    vm = createPicker({
+    }, {
+      select: selectHandle
+    })
+    new Promise((resolve) => {
+      vm.show()
+      vm.selectedIndex = [0, 1, 0]
+      setTimeout(() => {
+        let confirmBtn = vm.$el.querySelector('.cube-picker-confirm')
+        confirmBtn.click()
+        let value = selectHandle.lastCall.args[0]
+        setTimeout(() => {
+          resolve(value)
+        })
+      }, 100)
+    }).then((firstValue) => {
+      vm.show()
+      setTimeout(() => {
+        let confirmBtn = vm.$el.querySelector('.cube-picker-confirm')
+        confirmBtn.click()
+        let value = selectHandle.lastCall.args[0]
+        expect(firstValue)
+          .to.be.equal(value)
+        done()
+      }, 100)
+    })
+  })
+
   testMinuteStep()
 
   testMin()


### PR DESCRIPTION
When the showNow props is used and the selectedIndex collection is [0, 1, 0], opening the time-picker again will show just now
