### PR TITLE
Fix time picker

### DIFF
--- a/src/components/time-picker/time-picker.vue
+++ b/src/components/time-picker/time-picker.vue
@@ -259,7 +259,10 @@
         const value = this.value
         const minTime = this.minTime
         // fix the value last choose was changed when time-picker is opened again
-        if (value < Math.floor(minTime / MINUTE_TIMESTAMP) * MINUTE_TIMESTAMP) {
+        const comparativeTime = (this.min || this.min === 0)
+          ? +minTime
+          : Math.floor(minTime / MINUTE_TIMESTAMP) * MINUTE_TIMESTAMP
+        if (value < comparativeTime) {
           this.selectedIndex = [0, 0, 0]
         } else {
           // calculate dayIndex


### PR DESCRIPTION
Select `min` props to get  the variable `comparativeTime`