### PR TITLE
fix(dos):修复数据children为空的情况，读取属性报错

### DIFF
--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -186,7 +186,10 @@
       },
       refillColumn(index, data) {
         const wheelWrapper = this.$refs.wheelWrapper
-        let scroll = wheelWrapper.children[index].querySelector('.cube-picker-wheel-scroll')
+        let scroll
+        if (wheelWrapper.children[index]) {
+          scroll = wheelWrapper.children[index].querySelector('.cube-picker-wheel-scroll')
+        }
         let wheel = this.wheels ? this.wheels[index] : false
         let dist = 0
         if (scroll && wheel) {


### PR DESCRIPTION

![fix_bug_1](https://user-images.githubusercontent.com/22431734/80445421-cdb30900-8946-11ea-8224-640cfadd403a.png)
![fix_bug_2](https://user-images.githubusercontent.com/22431734/80445427-d1469000-8946-11ea-8414-c67cfc5e93a7.png)
![fix_bug_3](https://user-images.githubusercontent.com/22431734/80445431-d4da1700-8946-11ea-90ec-17a2aefd107d.png)
children层级不同时，为空时添加判断。