### PR TITLE
fix: 下拉刷新操作未完成时，进入其他页面，scroll被销毁，但仍会执行scroll实例中的finishPullDown方法，导致报错

### DIFF
--- a/src/components/scroll/scroll.vue
+++ b/src/components/scroll/scroll.vue
@@ -482,7 +482,7 @@
         const {stopTime = DEFAULT_STOP_TIME} = this.pullDownRefresh
         return new Promise(resolve => {
           setTimeout(() => {
-            this.scroll.finishPullDown()
+            this.scroll && this.scroll.finishPullDown()
             resolve()
           }, stopTime)
         })
@@ -493,7 +493,7 @@
             this.pullDownStyle = `top: -${this.pullDownHeight}px`
             this.beforePullDown = true
             resolve()
-          }, this.scroll.options.bounceTime)
+          }, this.scroll && this.scroll.options.bounceTime)
         })
       },
       _getPullDownEleHeight() {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow DiDi's [contributing guide](https://github.com/didi/cube-ui/blob/master/CONTRIBUTING.md).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
